### PR TITLE
AB#42: User Invitation Modal

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -24,6 +24,7 @@
     "react/jsx-filename-extension": [1, { "extensions": [".tsx", ".ts"] }],
     "react/jsx-uses-react": "off",
     "react/react-in-jsx-scope": "off",
-    "react/require-default-props": "off"
+    "react/require-default-props": "off",
+    "react/jsx-props-no-spreading": "off"
   }
 }

--- a/src/components/NoOrganization.tsx
+++ b/src/components/NoOrganization.tsx
@@ -73,9 +73,9 @@ const NoOrganization = () => {
           flexDirection="column"
           py={10}
           px={10}
-          width={{ sm: '90%', md: '80%', lg: '80%', xl: '50%' }}
+          width={{ sm: '90%', md: '80%', lg: '80%', xl: '55%' }}
         >
-          <Text fontSize={['24px', '24px', '30px', '40px', '44px']}>
+          <Text fontSize={['24px', '24px', '30px', '40px', '36px']}>
             You do not currently own or belong to any organization.
           </Text>
           <Text fontSize={['14px', '14px', '20px', '20px', '24px']}>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,9 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import NoOrganization from '../components/NoOrganization';
-import userService, { UserOrganization } from '../services/user.service';
+import userService, { Organization } from '../services/user.service';
 
 function Dashboard() {
-  const [organizations, setOrganizations] = useState<Array<UserOrganization>>(
+  const [organizations, setOrganizations] = useState<Array<Organization>>(
     []
   );
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import NoOrganization from '../components/NoOrganization';
-import userService, { Organization } from '../services/user.service';
+import organizationService, { Organization } from '../services/organization.service';
 
 function Dashboard() {
   const [organizations, setOrganizations] = useState<Array<Organization>>(
@@ -8,7 +8,7 @@ function Dashboard() {
   );
 
   useEffect(() => {
-    userService.getCurrentUserOrganizations().then(setOrganizations);
+    organizationService.getCurrentUserOrganizations().then(setOrganizations);
   }, []);
 
   return (

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import NoOrganization from '../components/NoOrganization';
-import organizationService, { Organization } from '../services/organization.service';
+import organizationService, {
+  Organization,
+} from '../services/organization.service';
 
 function Dashboard() {
-  const [organizations, setOrganizations] = useState<Array<Organization>>(
-    []
-  );
+  const [organizations, setOrganizations] = useState<Array<Organization>>([]);
 
   useEffect(() => {
     organizationService.getCurrentUserOrganizations().then(setOrganizations);

--- a/src/pages/EditOrganization.tsx
+++ b/src/pages/EditOrganization.tsx
@@ -47,8 +47,7 @@ const OrganizationForm = () => {
     if (organization)
       OrganizationService.updateOrganization(organization?.id, { name })
         .then(() => {
-          organization.name = name;          
-          setOrganization(organization);
+          setOrganization({...organization, name});
           toast({
             position: 'bottom-right',
             status: 'success',

--- a/src/pages/Organizations.tsx
+++ b/src/pages/Organizations.tsx
@@ -39,7 +39,6 @@ import { useUser } from '../contexts/user-context';
 import OrganizationService, {
   Organization,
 } from '../services/organization.service';
-import UserService from '../services/user.service';
 
 const NewOrganizationModel = ({
   isOpen,
@@ -106,7 +105,7 @@ function Organizations() {
   const toast = useToast();
 
   useEffect(() => {
-    UserService.getCurrentUserOrganizations().then(setOrganizations);
+    OrganizationService.getCurrentUserOrganizations().then(setOrganizations);
   }, []);
 
   const onClickNewOrganization = () => {

--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -2,7 +2,7 @@ import { render, waitFor, screen } from '@testing-library/react';
 import OrganizationService from '../../services/organization.service';
 import Dashboard from '../Dashboard';
 
-jest.mock('../../services/user.service');
+jest.mock('../../services/organization.service');
 
 describe('Dashboard', () => {
   let getOrganizationsSpy: jest.SpyInstance;
@@ -12,11 +12,6 @@ describe('Dashboard', () => {
       OrganizationService,
       'getCurrentUserOrganizations'
     );
-  });
-
-  test('gets and displays the current user', async () => {
-    render(<Dashboard />);
-    await waitFor(() => expect(getOrganizationsSpy).toBeCalledTimes(1));
   });
 
   test('displays no organizations if user belongs to no organizations', async () => {

--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -1,5 +1,5 @@
 import { render, waitFor, screen } from '@testing-library/react';
-import userService from '../../services/user.service';
+import OrganizationService from '../../services/organization.service';
 import Dashboard from '../Dashboard';
 
 jest.mock('../../services/user.service');
@@ -7,7 +7,7 @@ jest.mock('../../services/user.service');
 describe('Dashboard', () => {
   test('gets and displays the current user', async () => {
     const getOrganizationsSpy = jest.spyOn(
-      userService,
+      OrganizationService,
       'getCurrentUserOrganizations'
     );
     render(<Dashboard />);
@@ -16,7 +16,7 @@ describe('Dashboard', () => {
 
   test('displays no organizations if user belongs to no organizations', async () => {
     const getOrganizationsSpy = jest.spyOn(
-      userService,
+      OrganizationService,
       'getCurrentUserOrganizations'
     );
 

--- a/src/pages/__tests__/Dashboard.test.tsx
+++ b/src/pages/__tests__/Dashboard.test.tsx
@@ -5,26 +5,39 @@ import Dashboard from '../Dashboard';
 jest.mock('../../services/user.service');
 
 describe('Dashboard', () => {
-  test('gets and displays the current user', async () => {
-    const getOrganizationsSpy = jest.spyOn(
+  let getOrganizationsSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    getOrganizationsSpy = jest.spyOn(
       OrganizationService,
       'getCurrentUserOrganizations'
     );
+  });
+
+  test('gets and displays the current user', async () => {
     render(<Dashboard />);
     await waitFor(() => expect(getOrganizationsSpy).toBeCalledTimes(1));
   });
 
   test('displays no organizations if user belongs to no organizations', async () => {
-    const getOrganizationsSpy = jest.spyOn(
-      OrganizationService,
-      'getCurrentUserOrganizations'
-    );
-
     getOrganizationsSpy.mockResolvedValue([]);
 
     render(<Dashboard />);
     await waitFor(() => expect(getOrganizationsSpy).toBeCalledTimes(1));
 
     expect(screen.getByTestId('no_org_container')).toBeInTheDocument();
+  });
+
+  test('displays welcome if the user does belong to an organization', async () => {
+    getOrganizationsSpy.mockResolvedValue([{}]);
+
+    render(<Dashboard />);
+    await waitFor(() => expect(getOrganizationsSpy).toBeCalledTimes(1));
+
+    expect(screen.getByText('Welcome to the dashboard!')).toBeInTheDocument();
+  });
+
+  afterEach(() => {
+    getOrganizationsSpy.mockRestore();
   });
 });

--- a/src/pages/__tests__/EditOrganization.test.tsx
+++ b/src/pages/__tests__/EditOrganization.test.tsx
@@ -26,7 +26,7 @@ describe('EditOrganization', () => {
 
   let inviteUserSpy: jest.SpyInstance<
     Promise<OrganizationUser>,
-    [id: number, values: Pick<OrganizationUser, 'user_id'>]
+    [id: number, email: string, role_id: number]
   >;
 
   beforeEach(() => {
@@ -40,6 +40,7 @@ describe('EditOrganization', () => {
     });
 
     updateOrgSpy = jest.spyOn(OrganizationService, 'updateOrganization');
+    inviteUserSpy = jest.spyOn(OrganizationService, 'inviteUser');
   });
 
   test('renders an input with the current organization name', async () => {
@@ -121,7 +122,7 @@ describe('EditOrganization', () => {
     fireEvent.click(submit);
 
     await waitFor(() =>
-      expect(inviteUserSpy).toHaveBeenCalledWith(1, { email: 'test@test.com', role_id: 2 })
+      expect(inviteUserSpy).toHaveBeenCalledWith(1, 'test@test.com', 2)
     );
   });
 
@@ -140,7 +141,7 @@ describe('EditOrganization', () => {
     fireEvent.click(submit);
 
     await waitFor(() =>
-      expect(screen.getByText('ErrorMessage')).toBeVisible()
+      expect(screen.getByText('Invitation Failed')).toBeVisible()
     );
   });
 

--- a/src/pages/__tests__/EditOrganization.test.tsx
+++ b/src/pages/__tests__/EditOrganization.test.tsx
@@ -11,6 +11,7 @@ jest.mock('react-router');
 jest.mock('../../services/organization.service', () => ({
   updateOrganization: () => Promise.resolve({}),
   getOrganizationUsers: () => Promise.resolve([{ user_id: 1 }]),
+  inviteUser: () => Promise.resolve({ organization_id: 1, user_id: 1, role_id: 2 }),
 }));
 
 const useOrganizationMock: jest.Mock = useOrganization as any;
@@ -74,7 +75,7 @@ describe('EditOrganization', () => {
   });
 
   test('renders a failure toast when update fails', async () => {
-    updateOrgSpy.mockRejectedValueOnce('Bad');
+    updateOrgSpy.mockRejectedValueOnce({ errors: ['ErrorMessage'] });
 
     render(<EditOrganization />);
 
@@ -82,7 +83,7 @@ describe('EditOrganization', () => {
     fireEvent.click(submit);
 
     await waitFor(() =>
-      expect(screen.getByText('Organization Update Failed')).toBeVisible()
+      expect(screen.getByText('ErrorMessage')).toBeVisible()
     );
   });
 

--- a/src/pages/__tests__/EditOrganization.test.tsx
+++ b/src/pages/__tests__/EditOrganization.test.tsx
@@ -126,6 +126,39 @@ describe('EditOrganization', () => {
     );
   });
 
+  test('invite user modal requires valid email', async () => {
+    inviteUserSpy.mockResolvedValue({ organization_id: 1, user_id: 2, role_id: 2 } as any);
+
+    render(<EditOrganization />);
+
+    const button = screen.getByText('Invite');
+    fireEvent.click(button);
+
+    const input = screen.getByPlaceholderText('Email');
+    fireEvent.change(input, { target: { value: 'test' } });
+
+    await waitFor(() =>
+    expect(screen.getByText('Invalid email address')).toBeVisible()
+    );
+  });
+
+  test('invite user modal requires entry', async () => {
+    inviteUserSpy.mockResolvedValue({ organization_id: 1, user_id: 2, role_id: 2 } as any);
+
+    render(<EditOrganization />);
+
+    const button = screen.getByText('Invite');
+    fireEvent.click(button);
+
+    const input = screen.getByPlaceholderText('Email');
+    fireEvent.change(input, { target: { value: ' ' } });
+    fireEvent.change(input, { target: { value: '' } });
+
+    await waitFor(() =>
+    expect(screen.getByText('Required')).toBeVisible()
+    );
+  });
+
   test('renders a failure toast when invite user fails', async () => {
     inviteUserSpy.mockRejectedValueOnce({ errors: ['ErrorMessage'] });
 

--- a/src/pages/__tests__/EditOrganization.test.tsx
+++ b/src/pages/__tests__/EditOrganization.test.tsx
@@ -81,6 +81,24 @@ describe('EditOrganization', () => {
     await waitFor(() => expect(updateOrgSpy).toHaveBeenCalledTimes(0));
   });
 
+
+  test('does not invite user if no current organization', async () => {
+    useOrganizationMock.mockReturnValue({ organization: undefined });
+
+    render(<EditOrganization />);
+
+    const button = screen.getByText('Invite');
+    fireEvent.click(button);
+
+    const input = screen.getByPlaceholderText('Email');
+    fireEvent.change(input, { target: { value: 'test@test.com' } });
+
+    const submit = screen.getByText('Send Invitation');
+    fireEvent.click(submit);
+
+    await waitFor(() => expect(inviteUserSpy).toHaveBeenCalledTimes(0));
+  });
+
   test('renders a failure toast when update fails', async () => {
     updateOrgSpy.mockRejectedValueOnce({ errors: ['ErrorMessage'] });
 
@@ -91,6 +109,19 @@ describe('EditOrganization', () => {
 
     await waitFor(() =>
       expect(screen.getByText('ErrorMessage')).toBeVisible()
+    );
+  });
+
+  test('renders a failure toast when update fails with no error message', async () => {
+    updateOrgSpy.mockRejectedValueOnce({ errors: undefined });
+
+    render(<EditOrganization />);
+
+    const submit = screen.getByText('Save');
+    fireEvent.click(submit);
+
+    await waitFor(() =>
+      expect(screen.getByText('Organization Update Failed')).toBeVisible()
     );
   });
 

--- a/src/pages/__tests__/Organizations.test.tsx
+++ b/src/pages/__tests__/Organizations.test.tsx
@@ -29,7 +29,7 @@ const triggerCreation = async () => {
 };
 
 describe('Organizations', () => {
-  let getOrganizationsSpy: jest.SpyInstance<Promise<UserOrganization[]>, []>;
+  let getOrganizationsSpy: jest.SpyInstance<Promise<Organization[]>, []>;
   let deleteOrgSpy: jest.SpyInstance<Promise<string>, [id: number]>;
   let createOrgSpy: jest.SpyInstance<Promise<Organization>, [name: string]>;
 

--- a/src/pages/__tests__/Organizations.test.tsx
+++ b/src/pages/__tests__/Organizations.test.tsx
@@ -7,9 +7,8 @@ import {
 } from '@testing-library/react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { useUser } from '../../contexts/user-context';
-import userService, { Organization } from '../../services/user.service';
 import Organizations from '../Organizations';
-import OrganizationService from '../../services/organization.service';
+import OrganizationService, { Organization } from '../../services/organization.service';
 
 jest.mock('../../services/user.service');
 jest.mock('../../contexts/user-context');
@@ -58,7 +57,7 @@ describe('Organizations', () => {
     });
 
     getOrganizationsSpy = jest.spyOn(
-      userService,
+      OrganizationService,
       'getCurrentUserOrganizations'
     );
 

--- a/src/pages/__tests__/Organizations.test.tsx
+++ b/src/pages/__tests__/Organizations.test.tsx
@@ -7,11 +7,9 @@ import {
 } from '@testing-library/react';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { useUser } from '../../contexts/user-context';
-import userService, { UserOrganization } from '../../services/user.service';
+import userService, { Organization } from '../../services/user.service';
 import Organizations from '../Organizations';
-import OrganizationService, {
-  Organization,
-} from '../../services/organization.service';
+import OrganizationService from '../../services/organization.service';
 
 jest.mock('../../services/user.service');
 jest.mock('../../contexts/user-context');

--- a/src/services/__mocks__/organization.service.ts
+++ b/src/services/__mocks__/organization.service.ts
@@ -17,11 +17,11 @@ const OrganizationService = {
         username: 'testUser',
       },
     }),
-    inviteUser: (id: number, email: string, role_id: number) =>
+  inviteUser: () =>
     Promise.resolve({
       organization_id: 1,
       user_id: 1,
-      role_id: 2
+      role_id: 2,
     }),
   deleteOrganization: () => Promise.resolve(''),
   getCurrentUserOrganizations: () =>

--- a/src/services/__mocks__/organization.service.ts
+++ b/src/services/__mocks__/organization.service.ts
@@ -26,6 +26,12 @@ const OrganizationService = {
         username: 'testUser',
       },
     }),
+    inviteUser: (id: number, email: string, role_id: number) =>
+    Promise.resolve({
+      organization_id: 1,
+      user_id: 1,
+      role_id: 2
+    }),
   deleteOrganization: () => Promise.resolve(''),
 };
 

--- a/src/services/__mocks__/organization.service.ts
+++ b/src/services/__mocks__/organization.service.ts
@@ -8,15 +8,6 @@ const OrganizationService = {
         username: 'testUser',
       },
     }),
-
-  getOrganizationUsers: () =>
-    Promise.resolve([
-      {
-        organization_id: 1,
-        user_id: 1,
-        role_id: null,
-      },
-    ]),
   createOrganization: (name: string) =>
     Promise.resolve({
       id: 1,
@@ -33,6 +24,17 @@ const OrganizationService = {
       role_id: 2
     }),
   deleteOrganization: () => Promise.resolve(''),
+  getCurrentUserOrganizations: () =>
+    Promise.resolve([
+      {
+        id: 1,
+        name: 'testOrg',
+        owner: {
+          id: 1,
+          username: 'testUser',
+        },
+      },
+    ]),
 };
 
 export default OrganizationService;

--- a/src/services/__mocks__/user.service.ts
+++ b/src/services/__mocks__/user.service.ts
@@ -4,18 +4,6 @@ const UserService = {
       id: 1,
       username: 'testUser',
     }),
-
-  getCurrentUserOrganizations: () =>
-    Promise.resolve([
-      {
-        id: 1,
-        name: 'testOrg',
-        owner: {
-          id: 1,
-          username: 'testUser',
-        },
-      },
-    ]),
 };
 
 export default UserService;

--- a/src/services/__tests__/organization.service.test.ts
+++ b/src/services/__tests__/organization.service.test.ts
@@ -3,8 +3,15 @@ import organizationService from '../organization.service';
 describe('organizationService', () => {
   it('gets organization by id', async () => {
     const org = { id: 1, name: 'testOrg', owner: { id: 1, username: 'test' } };
+    const requestHeader: HeadersInit = new Headers();
+    requestHeader.set('Content-Type', 'application/json');
+
     global.fetch = jest.fn(() =>
-      Promise.resolve({ ok: true, json: () => Promise.resolve(org) } as any)
+      Promise.resolve({
+        ok: true,
+        headers: requestHeader,
+        json: () => Promise.resolve(org)
+      } as any)
     );
 
     const searchOrg = await organizationService.getOrganizationById(1);
@@ -18,13 +25,47 @@ describe('organizationService', () => {
     );
   });
 
+  it('gets the current user organizations', async () => {
+    const org = [
+      { id: 1, name: 'testOrg', owner: { id: 1, username: 'test' } },
+    ];
+    const requestHeader: HeadersInit = new Headers();
+    requestHeader.set('Content-Type', 'application/json');
+
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        headers: requestHeader,
+        json: () => Promise.resolve(org)
+      } as any)
+    );
+
+    const currentUserOrgs = await organizationService.getCurrentUserOrganizations();
+
+    expect(currentUserOrgs).toEqual(org);
+    expect(global.fetch).toBeCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        headers: { Authorization: expect.any(String) },
+      })
+    );
+  });
+
+  afterEach(() => {
+    (global.fetch as jest.Mock).mockRestore();
+  });
+
   it('gets organization user by id', async () => {
     const organizationUsers = [
       { organization_id: 1, user_id: 1, role_id: null },
     ];
+    const requestHeader: HeadersInit = new Headers();
+    requestHeader.set('Content-Type', 'application/json');
+
     global.fetch = jest.fn(() =>
       Promise.resolve({
         ok: true,
+        headers: requestHeader,
         json: () => Promise.resolve(organizationUsers),
       } as any)
     );
@@ -48,10 +89,13 @@ describe('organizationService', () => {
       name,
       owner: { id: 0, username: 'testUser' },
     };
+    const requestHeader: HeadersInit = new Headers();
+    requestHeader.set('Content-Type', 'application/json');
 
     global.fetch = jest.fn(() =>
       Promise.resolve({
         ok: true,
+        headers: requestHeader,
         json: () => Promise.resolve(organization),
       } as any)
     );
@@ -81,10 +125,13 @@ describe('organizationService', () => {
       name,
       owner: { id: 0, username: 'testUser' },
     };
+    const requestHeader: HeadersInit = new Headers();
+    requestHeader.set('Content-Type', 'application/json');
 
     global.fetch = jest.fn(() =>
       Promise.resolve({
         ok: true,
+        headers: requestHeader,
         json: () => Promise.resolve(organization),
       } as any)
     );
@@ -113,6 +160,7 @@ describe('organizationService', () => {
     global.fetch = jest.fn(() =>
       Promise.resolve({
         ok: true,
+        headers: { 'Content-Type': 'application/json' },
         text: () => Promise.resolve(''),
       } as any)
     );

--- a/src/services/__tests__/organization.service.test.ts
+++ b/src/services/__tests__/organization.service.test.ts
@@ -10,7 +10,7 @@ describe('organizationService', () => {
       Promise.resolve({
         ok: true,
         headers: requestHeader,
-        json: () => Promise.resolve(org)
+        json: () => Promise.resolve(org),
       } as any)
     );
 
@@ -36,11 +36,12 @@ describe('organizationService', () => {
       Promise.resolve({
         ok: true,
         headers: requestHeader,
-        json: () => Promise.resolve(org)
+        json: () => Promise.resolve(org),
       } as any)
     );
 
-    const currentUserOrgs = await organizationService.getCurrentUserOrganizations();
+    const currentUserOrgs =
+      await organizationService.getCurrentUserOrganizations();
 
     expect(currentUserOrgs).toEqual(org);
     expect(global.fetch).toBeCalledWith(
@@ -174,6 +175,38 @@ describe('organizationService', () => {
         headers: {
           Authorization: expect.any(String),
         },
+      })
+    );
+  });
+
+  test('invites a user by email', () => {
+    organizationService.inviteUser(1, 'test@test.com', 1);
+
+    expect(global.fetch).toBeCalledWith(
+      expect.stringContaining('/organizations/1/users'),
+      expect.objectContaining({
+        method: 'POST',
+        headers: {
+          Authorization: expect.any(String),
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: 'test@test.com',
+          role_id: 1,
+        }),
+      })
+    );
+  });
+
+  test('gets the current users organizations', () => {
+    organizationService.getCurrentUserJoinedOrganizations();
+
+    expect(global.fetch).toBeCalledWith(
+      expect.stringContaining('/users/me/organizations/joined'),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          Authorization: expect.any(String),
+        }),
       })
     );
   });

--- a/src/services/__tests__/service.test.ts
+++ b/src/services/__tests__/service.test.ts
@@ -1,38 +1,44 @@
 import Service from '../service';
 
 describe('service', () => {
+  const service = new Service() as any;
   const response = { message: 'bad' };
 
   beforeEach(() => {
     global.fetch = jest.fn(() =>
       Promise.resolve({
         ok: false,
+        headers: { get: () => 'application/json' },
         json: () => Promise.resolve(response),
       } as any)
     );
   });
 
-  test('get rejects on request failure', () => {
-    const service = new Service() as any;
+  test('returns response text if Json is not present', () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        headers: { get: () => 'application/text' },
+        text: () => 'text',
+      } as any)
+    );
 
+    expect(service.get('/')).resolves.toEqual('text');
+  });
+
+  test('get rejects on request failure', () => {
     expect(service.get('/')).rejects.toEqual(response);
   });
 
   test('patch rejects on request failure', () => {
-    const service = new Service() as any;
-
     expect(service.patch('/')).rejects.toEqual(response);
   });
 
   test('post rejects on request failure', () => {
-    const service = new Service() as any;
-
     expect(service.post('/')).rejects.toEqual(response);
   });
 
   test('delete rejects on a failure', () => {
-    const service = new Service() as any;
-
     expect(service.delete('/')).rejects.toEqual(response);
   });
 

--- a/src/services/__tests__/user.service.test.ts
+++ b/src/services/__tests__/user.service.test.ts
@@ -3,8 +3,14 @@ import userService from '../user.service';
 describe('userService', () => {
   it('gets the current user', async () => {
     const user = { id: 1, username: 'test' };
+    const requestHeader: HeadersInit = new Headers();
+    requestHeader.set('Content-Type', 'application/json');
     global.fetch = jest.fn(() =>
-      Promise.resolve({ ok: true, json: () => Promise.resolve(user) } as any)
+      Promise.resolve({
+        ok: true,
+        headers: requestHeader,
+        json: () => Promise.resolve(user)
+      } as any)
     );
 
     const currentUser = await userService.getCurrentUser();
@@ -16,28 +22,5 @@ describe('userService', () => {
         headers: { Authorization: expect.any(String) },
       })
     );
-  });
-
-  it('gets the current user organizations', async () => {
-    const org = [
-      { id: 1, name: 'testOrg', owner: { id: 1, username: 'test' } },
-    ];
-    global.fetch = jest.fn(() =>
-      Promise.resolve({ ok: true, json: () => Promise.resolve(org) } as any)
-    );
-
-    const currentUserOrgs = await userService.getCurrentUserOrganizations();
-
-    expect(currentUserOrgs).toEqual(org);
-    expect(global.fetch).toBeCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        headers: { Authorization: expect.any(String) },
-      })
-    );
-  });
-
-  afterEach(() => {
-    (global.fetch as jest.Mock).mockRestore();
   });
 });

--- a/src/services/organization.service.ts
+++ b/src/services/organization.service.ts
@@ -24,9 +24,7 @@ class OrganizationService extends DbApiService {
     return this.get(`/organizations/${id}/users`);
   }
 
-  public async createOrganization(
-    name: string
-  ): Promise<Organization> {
+  public async createOrganization(name: string): Promise<Organization> {
     return this.post(`/organizations`, { name });
   }
 
@@ -35,7 +33,7 @@ class OrganizationService extends DbApiService {
     email: string,
     role_id: number
   ): Promise<OrganizationUser> {
-    return this.post(`/organizations/${id}/users`, { email,  role_id });
+    return this.post(`/organizations/${id}/users`, { email, role_id });
   }
 
   public async updateOrganization(
@@ -53,7 +51,9 @@ class OrganizationService extends DbApiService {
     return this.get(`/users/me/organizations`);
   }
 
-  public async getCurrentUserJoinedOrganizations(): Promise<Array<OrganizationUser>> {
+  public async getCurrentUserJoinedOrganizations(): Promise<
+    Array<OrganizationUser>
+  > {
     return this.get(`/users/me/organizations/joined`);
   }
 }

--- a/src/services/organization.service.ts
+++ b/src/services/organization.service.ts
@@ -48,6 +48,14 @@ class OrganizationService extends DbApiService {
   public async deleteOrganization(id: number) {
     return this.delete(`/organizations/${id}`);
   }
+
+  public async getCurrentUserOrganizations(): Promise<Array<Organization>> {
+    return this.get(`/users/me/organizations`);
+  }
+
+  public async getCurrentUserJoinedOrganizations(): Promise<Array<OrganizationUser>> {
+    return this.get(`/users/me/organizations/joined`);
+  }
 }
 
 export default new OrganizationService();

--- a/src/services/organization.service.ts
+++ b/src/services/organization.service.ts
@@ -24,8 +24,18 @@ class OrganizationService extends DbApiService {
     return this.get(`/organizations/${id}/users`);
   }
 
-  public async createOrganization(name: string): Promise<Organization> {
+  public async createOrganization(
+    name: string
+  ): Promise<Organization> {
     return this.post(`/organizations`, { name });
+  }
+
+  public async inviteUser(
+    id: number,
+    email: string,
+    role_id: number
+  ): Promise<OrganizationUser> {
+    return this.post(`/organizations/${id}/users`, { email,  role_id });
   }
 
   public async updateOrganization(

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -8,13 +8,7 @@ class Service {
       headers: getAuthenticationHeader(),
     });
 
-
-    if(response.headers.get('Content-Type') === 'application/json'){
-      const json = response.json();
-      return response.ok ? json : json.then(Promise.reject.bind(Promise));
-    }
-
-    return response.ok ? Promise.resolve({}) : Promise.reject.bind(Promise);
+    return this.processResponse(response);
   }
 
   protected async post(endpoint: string, body: any) {
@@ -27,13 +21,7 @@ class Service {
       body: JSON.stringify(body),
     });
 
-
-    if(response.headers.get('Content-Type') === 'application/json'){
-      const json = response.json();
-      return response.ok ? json : json.then(Promise.reject.bind(Promise));
-    }
-
-    return response.ok ? Promise.resolve({}) : Promise.reject.bind(Promise);
+    return this.processResponse(response);
   }
 
   protected async patch(endpoint: string, body: any) {
@@ -46,12 +34,7 @@ class Service {
       body: JSON.stringify(body),
     });
 
-    if(response.headers.get('Content-Type') === 'application/json'){
-      const json = response.json();
-      return response.ok ? json : json.then(Promise.reject.bind(Promise));
-    }
-
-    return response.ok ? Promise.resolve({}) : Promise.reject.bind(Promise);
+    return this.processResponse(response);
   }
 
   protected async delete(endpoint: string) {
@@ -62,8 +45,17 @@ class Service {
       method: 'DELETE',
     });
 
-    /* if response OK (HTTP 2XX) return result -- otherwise reject promise so exception is invoked */
-    return response.ok ? response.text() : Promise.reject(response.statusText);
+    return this.processResponse(response);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  private processResponse(response: Response) {
+    const body =
+      response.headers.get('Content-Type') === 'application/json'
+        ? response.json()
+        : response.text();
+
+    return response.ok ? body : Promise.reject.bind(Promise);
   }
 }
 

--- a/src/services/service.ts
+++ b/src/services/service.ts
@@ -8,9 +8,13 @@ class Service {
       headers: getAuthenticationHeader(),
     });
 
-    /* if response OK (HTTP 2XX) return result -- otherwise reject promise so exception is invoked */
-    const json = response.json();
-    return response.ok ? json : json.then(Promise.reject.bind(Promise));
+
+    if(response.headers.get('Content-Type') === 'application/json'){
+      const json = response.json();
+      return response.ok ? json : json.then(Promise.reject.bind(Promise));
+    }
+
+    return response.ok ? Promise.resolve({}) : Promise.reject.bind(Promise);
   }
 
   protected async post(endpoint: string, body: any) {
@@ -23,9 +27,13 @@ class Service {
       body: JSON.stringify(body),
     });
 
-    /* if response OK (HTTP 2XX) return result -- otherwise reject promise so exception is invoked */
-    const json = response.json();
-    return response.ok ? json : json.then(Promise.reject.bind(Promise));
+
+    if(response.headers.get('Content-Type') === 'application/json'){
+      const json = response.json();
+      return response.ok ? json : json.then(Promise.reject.bind(Promise));
+    }
+
+    return response.ok ? Promise.resolve({}) : Promise.reject.bind(Promise);
   }
 
   protected async patch(endpoint: string, body: any) {
@@ -38,9 +46,12 @@ class Service {
       body: JSON.stringify(body),
     });
 
-    /* if response OK (HTTP 2XX) return result -- otherwise reject promise so exception is invoked */
-    const json = response.json();
-    return response.ok ? json : json.then(Promise.reject.bind(Promise));
+    if(response.headers.get('Content-Type') === 'application/json'){
+      const json = response.json();
+      return response.ok ? json : json.then(Promise.reject.bind(Promise));
+    }
+
+    return response.ok ? Promise.resolve({}) : Promise.reject.bind(Promise);
   }
 
   protected async delete(endpoint: string) {

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -5,19 +5,29 @@ export type User = {
   username: string;
 };
 
-export type UserOrganization = {
+export type Organization = {
   id: number;
   name: string;
   owner: User;
 };
+
+export type OrganizationUser = {
+  organization_id: number;
+  user_id: number;
+  role_id: number;
+}
 
 class UserService extends DbApiService {
   public async getCurrentUser(): Promise<User> {
     return this.get(`/users/me`);
   }
 
-  public async getCurrentUserOrganizations(): Promise<Array<UserOrganization>> {
+  public async getCurrentUserOrganizations(): Promise<Array<Organization>> {
     return this.get(`/users/me/organizations`);
+  }
+
+  public async getCurrentUserJoinedOrganizations(): Promise<Array<OrganizationUser>> {
+    return this.get(`/users/me/organizations/joined`);
   }
 }
 

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -5,29 +5,9 @@ export type User = {
   username: string;
 };
 
-export type Organization = {
-  id: number;
-  name: string;
-  owner: User;
-};
-
-export type OrganizationUser = {
-  organization_id: number;
-  user_id: number;
-  role_id: number;
-}
-
 class UserService extends DbApiService {
   public async getCurrentUser(): Promise<User> {
     return this.get(`/users/me`);
-  }
-
-  public async getCurrentUserOrganizations(): Promise<Array<Organization>> {
-    return this.get(`/users/me/organizations`);
-  }
-
-  public async getCurrentUserJoinedOrganizations(): Promise<Array<OrganizationUser>> {
-    return this.get(`/users/me/organizations/joined`);
   }
 }
 


### PR DESCRIPTION
This branch adds a few things:
- Error message gets displayed in the toast notification when org update fails (i.e. blank name, org already exists)
- Redirect when attempting to view /edit page of an org user is not in (getOrganizationUsers returns unauthorized)
- Invite user button and modal with form that validates email format